### PR TITLE
handle #teardown being called multiple times

### DIFF
--- a/lib/logstash/inputs/journald.rb
+++ b/lib/logstash/inputs/journald.rb
@@ -125,6 +125,8 @@ class LogStash::Inputs::Journald < LogStash::Inputs::Threadable
 
     public
     def teardown # FIXME: doesn't really seem to work...
+        return finished unless @journal # Ignore multiple calls
+
         @logger.debug("journald shutting down.")
         @journal = nil
         Thread.kill(@sincedb_writer)


### PR DESCRIPTION
Per https://github.com/elastic/logstash/blob/v1.5.2/lib/logstash/pipeline.rb#L190:L192.

Not sure if this covers the intent of the `FIXME` note.
