### PR TITLE
Always move in journal when seeking to tail

### DIFF
--- a/lib/logstash/inputs/journald.rb
+++ b/lib/logstash/inputs/journald.rb
@@ -101,6 +101,15 @@ class LogStash::Inputs::Journald < LogStash::Inputs::Threadable
     def run(queue)
         if @cursor.strip.length == 0
             @journal.seek(@seekto.to_sym)
+
+            # We must make one movement in order for the journal C api or else
+            # the @journal.watch call will start from the beginning of the
+            # journal. see:
+            # https://github.com/ledbettj/systemd-journal/issues/55
+            if @seekto == 'tail'
+              @journal.move_previous
+            end
+
             @journal.filter(@filter)
         else
             @journal.seek(@cursor)


### PR DESCRIPTION
First, thanks for taking a stab at this. I hope the logstash maintainers will help you out with it and eventually distribute it with logstash, since journald is going to blow up in popularity very soon.

According to [this Github issue](https://github.com/ledbettj/systemd-journal/issues/55) on the systemd-journal gem, you must
make one movement in the journal before methods like current_entry and
cursor are valid. Although neither are called in this plugin, the watch
method also behaves weirdly, in my testing it always starts from the
beginning of the journal even when given `seekto => "tail"`.

This appears to be a limitation of the journal C library itself, the
[documentation for which](http://www.freedesktop.org/software/systemd/man/sd_journal_get_data.html) states:

> Note that these functions will not work before sd_journal_next(3) (or
> related call) has been called at least once, in order to position the
> read pointer at a valid entry.

I tested this with my local CentOS 7 journal and verified that seeking
to the tail and then calling move_previous does not actually seek to
repeat the previous event.
