### PR TITLE
Add options like journalbeat, pump to 3.0.0 version

### DIFF
--- a/lib/logstash/inputs/journald.rb
+++ b/lib/logstash/inputs/journald.rb
@@ -155,7 +155,13 @@ class LogStash::Inputs::Journald < LogStash::Inputs::Threadable
     def watch_journal
         until stop?
             if @journal.wait(@wait_timeout)
-                yield @journal.current_entry while !stop? && @journal.move_next
+                while !stop? && @journal.move_next
+                    begin
+                        yield @journal.current_entry
+                    rescue => error
+                        @logger.error("Unable to read journald message skipping: #{error.message}")
+                    end
+                end
             end
         end
     end # def watch_journal

--- a/logstash-input-journald.gemspec
+++ b/logstash-input-journald.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'logstash-codec-json_lines'
   s.add_runtime_dependency 'ffi'
-  s.add_runtime_dependency 'systemd-journal', '~> 1.2.2'
+  s.add_runtime_dependency 'systemd-journal', '>= 1.3'
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-journald.gemspec
+++ b/logstash-input-journald.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency 'logstash-codec-json_lines'
   s.add_runtime_dependency 'ffi'
-  s.add_runtime_dependency 'systemd-journal', '>= 1.3'
+  s.add_runtime_dependency 'systemd-journal', '= 1.3.3'
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-journald.gemspec
+++ b/logstash-input-journald.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-journald'
-  s.version         = '2.0.2'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from local systemd journal"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
* Some fields can not be inserted like _uid as it is a reserved field
* Added an option like journalbeat which can move the fields in a sub hash except the message field
* systemd-journal gem has been updated

fix #26 