### PR TITLE
fixes #24 crashes forever on bad message

### DIFF
--- a/lib/logstash/inputs/journald.rb
+++ b/lib/logstash/inputs/journald.rb
@@ -155,7 +155,13 @@ class LogStash::Inputs::Journald < LogStash::Inputs::Threadable
     def watch_journal
         until stop?
             if @journal.wait(@wait_timeout)
-                yield @journal.current_entry while !stop? && @journal.move_next
+                while !stop? && @journal.move_next
+                    begin
+                        yield @journal.current_entry
+                    rescue => error
+                        @logger.error("Unable to read journald message skipping: #{error.message}")
+                    end
+                end
             end
         end
     end # def watch_journal


### PR DESCRIPTION
When a journald file is corrupted, logstash-input-journald will block
forever on the bad message.

This fixes it by simply skiping over the journald bad message and logging
the observed error.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
